### PR TITLE
Export apiRequest for forgot password requests

### DIFF
--- a/membri-api.js
+++ b/membri-api.js
@@ -5,7 +5,7 @@ const apiBase  = 'https://api.membri365.com/v1_01/';
 const apiSCode = 'rkTl0wgwFkJVxOURkz3tpwWcYols1flS4NdUZAcFzoBAckCxvl6tDr2XE5VGPgfG';
 const orgId    = 'ec4fb530-d07a-4e5c-81d2-b238d3ff2adb';
 
-async function apiRequest(path, { method = 'GET', query = '', body } = {}) {
+export async function apiRequest(path, { method = 'GET', query = '', body } = {}) {
   const url = `${apiBase}${path}?orgId=${orgId}${query}`;
   const headers = { 'Accept': 'application/json', 'SCode': apiSCode };
   if (body) headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
## Summary
- Export `apiRequest` so modules like forgot-password can call backend

## Testing
- `node --version`
- `node --check membri-api.js`
- `node --check page-forgot-password.js`


------
https://chatgpt.com/codex/tasks/task_b_68902a9f44f083239e0f303b881c2bba