### PR TITLE
Add tests for Membri API requests

### DIFF
--- a/membri-api.js
+++ b/membri-api.js
@@ -22,6 +22,8 @@ async function apiRequest(path, { method = 'GET', query = '', body } = {}) {
   return response.json();
 }
 
+export { apiRequest };
+
 /** Authentification */
 export async function loginMember(email, password) {
   return apiRequest('Member/Login', {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "asl",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/membri-api.test.js
+++ b/tests/membri-api.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { apiRequest } from '../membri-api.js';
+
+test('apiRequest constructs URL and headers correctly', async () => {
+  let captured = {};
+  global.fetch = async (url, options) => {
+    captured.url = url;
+    captured.options = options;
+    return { ok: true, json: async () => ({ result: 'ok' }) };
+  };
+
+  await apiRequest('Member/Login', {
+    method: 'POST',
+    query: '&foo=bar',
+    body: { hello: 'world' }
+  });
+
+  assert.equal(
+    captured.url,
+    'https://api.membri365.com/v1_01/Member/Login?orgId=ec4fb530-d07a-4e5c-81d2-b238d3ff2adb&foo=bar'
+  );
+  assert.deepEqual(captured.options.headers, {
+    Accept: 'application/json',
+    SCode: 'rkTl0wgwFkJVxOURkz3tpwWcYols1flS4NdUZAcFzoBAckCxvl6tDr2XE5VGPgfG',
+    'Content-Type': 'application/json'
+  });
+  assert.equal(captured.options.method, 'POST');
+  assert.equal(captured.options.body, JSON.stringify({ hello: 'world' }));
+});
+
+test('apiRequest throws on non-ok response', async () => {
+  global.fetch = async () => ({
+    ok: false,
+    status: 500,
+    text: async () => 'boom'
+  });
+
+  await assert.rejects(
+    apiRequest('Member/Login', { method: 'GET' }),
+    /API erreur GET Member\/Login: 500 - boom/
+  );
+});


### PR DESCRIPTION
## Summary
- export `apiRequest` to allow direct testing
- add unit tests mocking fetch to validate URL, headers, and error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890e03de4cc8323bf91d84675144597