### PR TITLE
Gérer l'absence d'ID d'adhésion sur la page paiement

### DIFF
--- a/page-payment.js
+++ b/page-payment.js
@@ -29,23 +29,29 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     // Historique des paiements
-    const payments = await getMembershipPayments(membershipId);
     const tbody = document.getElementById('payment-list');
-    if (payments.length === 0) {
-      tbody.innerHTML = `<tr><td colspan="4" class="px-6 py-4 text-center text-secondary">Aucun paiement enregistré.</td></tr>`;
+    if (membershipId) {
+      const payments = await getMembershipPayments(membershipId);
+      if (payments.length === 0) {
+        tbody.innerHTML =
+          '<tr><td colspan="4" class="px-6 py-4 text-center text-secondary">Aucun paiement enregistré.</td></tr>';
+      } else {
+        payments.forEach(p => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `
+            <td class="px-6 py-4 whitespace-nowrap text-secondary">${new Date(p.Date).toLocaleDateString('fr-FR')}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-primary">${p.Amount.toFixed(2)} €</td>
+            <td class="px-6 py-4 whitespace-nowrap text-secondary">${p.Status}</td>
+            <td class="px-6 py-4 text-right">
+              ${p.ReceiptUrl ? `<a href="${p.ReceiptUrl}" target="_blank" class="text-primary hover:underline">Reçu</a>` : ''}
+            </td>
+          `;
+          tbody.appendChild(tr);
+        });
+      }
     } else {
-      payments.forEach(p => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `
-          <td class="px-6 py-4 whitespace-nowrap text-secondary">${new Date(p.Date).toLocaleDateString('fr-FR')}</td>
-          <td class="px-6 py-4 whitespace-nowrap text-primary">${p.Amount.toFixed(2)} €</td>
-          <td class="px-6 py-4 whitespace-nowrap text-secondary">${p.Status}</td>
-          <td class="px-6 py-4 text-right">
-            ${p.ReceiptUrl ? `<a href="${p.ReceiptUrl}" target="_blank" class="text-primary hover:underline">Reçu</a>` : ''}
-          </td>
-        `;
-        tbody.appendChild(tr);
-      });
+      tbody.innerHTML =
+        '<tr><td colspan="4" class="px-6 py-4 text-center text-secondary">ID d\'adhésion manquant.</td></tr>';
     }
   } catch (error) {
     console.error('Erreur chargement paiements :', error);


### PR DESCRIPTION
## Summary
- Ajout d'une vérification de l'ID d'adhésion avant la récupération des paiements
- Affichage d'un message lorsque l'ID d'adhésion est manquant

## Testing
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_b_6890e039c0348323ad036eaabbeca47c