### PR TITLE
Fix postal address placeholder

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -81,7 +81,7 @@
         </label>
         <label class="block">
           <span class="text-sm font-medium text-secondary">Adresse</span>
-          <input name="Address" type="text" id="address" placeholder="Adresse postal"
+            <input name="Address" type="text" id="address" placeholder="Adresse postale"
                  class="mt-1 block w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent">
         </label>
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- fix typo in profile address placeholder

## Testing
- `curl -I http://localhost:8000/profile.html`
- `npx puppeteer@22.10.0 --version` *(fails: 403 Forbidden)*
- `pip install playwright` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6890e03761a88323bd4f9951aceedf6c