### PR TITLE
Link custom stylesheet and fix API test

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+
+    <!-- Custom Styles -->
+    <link rel="stylesheet" href="asl_custom.css">
+
     <!-- GSAP for animations -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>

--- a/portail/membri-api.js
+++ b/portail/membri-api.js
@@ -22,8 +22,6 @@ export async function apiRequest(path, { method = 'GET', query = '', body } = {}
   return response.json();
 }
 
-export { apiRequest };
-
 /** Authentification */
 export async function loginMember(email, password) {
   return apiRequest('Member/Login', {

--- a/tests/membri-api.test.js
+++ b/tests/membri-api.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { apiRequest } from '../membri-api.js';
+import { apiRequest } from '../portail/membri-api.js';
 
 test('apiRequest constructs URL and headers correctly', async () => {
   let captured = {};


### PR DESCRIPTION
## Summary
- link custom CSS in the homepage for proper styling
- remove duplicate export in Membri API helper
- update API test to use correct path

## Testing
- `node --test tests/membri-api.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6890fa4e0e70832393a44407d7e9982c